### PR TITLE
계정 생성 setting api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,10 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // gson (테스트 코드 작성할 때 반환 받을 정보를 객체 타입이 아닌 문자열 타입으로 받기 위함.)
+    implementation group: 'com.google.code.gson', name: 'gson', version: '2.9.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/as/we/make/aswemake/account/controller/AccountController.java
+++ b/src/main/java/com/as/we/make/aswemake/account/controller/AccountController.java
@@ -1,0 +1,30 @@
+package com.as.we.make.aswemake.account.controller;
+
+import com.as.we.make.aswemake.account.request.AccountRequestDto;
+import com.as.we.make.aswemake.account.service.AccountService;
+import com.as.we.make.aswemake.share.ResponseBody;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/awm")
+@Slf4j
+@RestController
+public class AccountController {
+
+    private final AccountService accountService;
+
+    // 계정 생성
+    @PostMapping("/account/create")
+    public ResponseEntity<ResponseBody> createAccount(@RequestBody AccountRequestDto accountRequestDto){
+        log.info("계정 생성 api - controller : 아이디 = {}, 비밀번호 = {}, 권한 = {}", accountRequestDto.getAccountEmail(), accountRequestDto.getAccountPwd(), accountRequestDto.getAuthority());
+
+        return accountService.createAccount(accountRequestDto);
+    }
+
+}

--- a/src/main/java/com/as/we/make/aswemake/account/domain/Account.java
+++ b/src/main/java/com/as/we/make/aswemake/account/domain/Account.java
@@ -1,0 +1,28 @@
+package com.as.we.make.aswemake.account.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+@Entity
+public class Account {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long accountId;
+
+    @Column(nullable = false)
+    private String accountEmail;
+
+    @Column(nullable = false)
+    private String accountPwd;
+
+    @Column(nullable = false)
+    private String authority;
+}

--- a/src/main/java/com/as/we/make/aswemake/account/repository/AccountRepository.java
+++ b/src/main/java/com/as/we/make/aswemake/account/repository/AccountRepository.java
@@ -1,0 +1,11 @@
+package com.as.we.make.aswemake.account.repository;
+
+import com.as.we.make.aswemake.account.domain.Account;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AccountRepository extends JpaRepository<Account, Long> {
+
+    Account findByAccountEmail(String accountEmail);
+}

--- a/src/main/java/com/as/we/make/aswemake/account/request/AccountRequestDto.java
+++ b/src/main/java/com/as/we/make/aswemake/account/request/AccountRequestDto.java
@@ -1,0 +1,29 @@
+package com.as.we.make.aswemake.account.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+public class AccountRequestDto {
+
+    @NotNull(message = "아이디는 공백을 포함할 수 없습니다.")
+    @Email(regexp = "^[a-zA-Z0-9]+@[a-zA-Z]+.[a-z]+${4,12}$", message = "이메일 형식에 맞지 않습니다.")
+    private String accountEmail;
+
+    @NotNull(message = "비밀번호는 공백일 수 없습니다.")
+    @Pattern(regexp="(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{7,20}",
+            message = "비밀번호는 영어 대/소문자, 숫자, 특수기호가 최소한 1개씩은 포함이 되어있어야 하며, 7~20글자 이내여야 합니다.")
+    private String accountPwd;
+
+    @NotNull(message = "권한은 공백일 수 없습니다." )
+    private String authority;
+
+}

--- a/src/main/java/com/as/we/make/aswemake/account/response/AccountResponseDto.java
+++ b/src/main/java/com/as/we/make/aswemake/account/response/AccountResponseDto.java
@@ -1,0 +1,11 @@
+package com.as.we.make.aswemake.account.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class AccountResponseDto {
+    private String accountEmail;
+    private String authority;
+}

--- a/src/main/java/com/as/we/make/aswemake/account/service/AccountService.java
+++ b/src/main/java/com/as/we/make/aswemake/account/service/AccountService.java
@@ -1,0 +1,63 @@
+package com.as.we.make.aswemake.account.service;
+
+import com.as.we.make.aswemake.account.domain.Account;
+import com.as.we.make.aswemake.account.repository.AccountRepository;
+import com.as.we.make.aswemake.account.request.AccountRequestDto;
+import com.as.we.make.aswemake.account.response.AccountResponseDto;
+import com.as.we.make.aswemake.exception.AccountExceptionInterface;
+import com.as.we.make.aswemake.share.ResponseBody;
+import com.as.we.make.aswemake.share.StatusCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.LinkedHashMap;
+
+@RequiredArgsConstructor
+@Service
+public class AccountService {
+
+    private final AccountRepository accountRepository;
+    private final AccountExceptionInterface accountExceptionInterface;
+
+    // 계정 생성
+    public ResponseEntity<ResponseBody> createAccount(AccountRequestDto accountRequestDto) {
+
+        // 계정 생성 정보 요청 확인
+        if (accountExceptionInterface.checkAccountCreateInfo(accountRequestDto)) {
+            return new ResponseEntity<>(new ResponseBody(StatusCode.CANNOT_CREATE_ACCOUNT, null), HttpStatus.BAD_REQUEST);
+        }
+
+        // account entity 계정 생성 정보 input
+        Account account = Account.builder()
+                .accountEmail(accountRequestDto.getAccountEmail())
+                .accountPwd(accountRequestDto.getAccountPwd())
+                .authority(accountRequestDto.getAuthority())
+                .build();
+
+        // 계정 저장
+        accountRepository.save(account);
+
+        // 반환 객체
+        AccountResponseDto responseData = AccountResponseDto.builder()
+                .accountEmail(account.getAccountEmail())
+                .authority(account.getAuthority())
+                .build();
+
+        return new ResponseEntity<>(new ResponseBody(StatusCode.IT_WORK, resultSet("정상적으로 계정이 생성되었습니다.", responseData)), HttpStatus.OK);
+    }
+
+
+    // 최종적으로 결과를 반환하기 위한 method
+    private LinkedHashMap<String, Object> resultSet(String message, Object responseData) {
+
+        // 정상 반환 시 반환되는 메세지와 데이터
+        LinkedHashMap<String, Object> resultSet = new LinkedHashMap<>();
+        resultSet.put("resultMessage", message);
+        resultSet.put("resultData", responseData);
+
+        return resultSet;
+    }
+
+}

--- a/src/main/java/com/as/we/make/aswemake/exception/AccountException.java
+++ b/src/main/java/com/as/we/make/aswemake/exception/AccountException.java
@@ -1,0 +1,20 @@
+package com.as.we.make.aswemake.exception;
+
+import com.as.we.make.aswemake.account.request.AccountRequestDto;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AccountException implements AccountExceptionInterface{
+
+    @Override
+    public boolean checkAccountCreateInfo(AccountRequestDto accountRequestDto) {
+
+        if(accountRequestDto.getAccountEmail() == null ||
+        accountRequestDto.getAccountPwd() == null ||
+        accountRequestDto.getAuthority() == null){
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/com/as/we/make/aswemake/exception/AccountExceptionInterface.java
+++ b/src/main/java/com/as/we/make/aswemake/exception/AccountExceptionInterface.java
@@ -1,0 +1,9 @@
+package com.as.we.make.aswemake.exception;
+
+import com.as.we.make.aswemake.account.request.AccountRequestDto;
+
+public interface AccountExceptionInterface {
+
+    /** 계정 생성 정보들 중에 null 값 유무 확인 **/
+    boolean checkAccountCreateInfo(AccountRequestDto accountRequestDto);
+}

--- a/src/main/java/com/as/we/make/aswemake/share/ResponseBody.java
+++ b/src/main/java/com/as/we/make/aswemake/share/ResponseBody.java
@@ -1,0 +1,17 @@
+package com.as.we.make.aswemake.share;
+
+import lombok.Getter;
+
+@Getter
+public class ResponseBody <T>{
+
+    private final String statusMessage;
+    private final Integer statusCode;
+    private final T data;
+
+    public ResponseBody(StatusCode statusCode, T data){
+        this.statusMessage = statusCode.statusMessage;
+        this.statusCode = statusCode.statusCode;
+        this.data = data;
+    }
+}

--- a/src/main/java/com/as/we/make/aswemake/share/StatusCode.java
+++ b/src/main/java/com/as/we/make/aswemake/share/StatusCode.java
@@ -1,0 +1,21 @@
+package com.as.we.make.aswemake.share;
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+
+@AllArgsConstructor
+@NoArgsConstructor
+public enum StatusCode {
+
+    // 정상 응답 처리
+    IT_WORK(200, "정상 처리"),
+
+    // 계정 생성 정보 요청 에러
+    CANNOT_CREATE_ACCOUNT(452, "계정 생성 요청 정보가 옳지 않아 생성할 수 없습니다.");
+
+    public Integer statusCode;
+    public String statusMessage;
+
+}

--- a/src/test/java/com/as/we/make/aswemake/AccountControllerTest.java
+++ b/src/test/java/com/as/we/make/aswemake/AccountControllerTest.java
@@ -1,0 +1,91 @@
+package com.as.we.make.aswemake;
+
+import com.as.we.make.aswemake.account.controller.AccountController;
+import com.as.we.make.aswemake.account.repository.AccountRepository;
+import com.as.we.make.aswemake.account.request.AccountRequestDto;
+import com.as.we.make.aswemake.account.response.AccountResponseDto;
+import com.as.we.make.aswemake.account.service.AccountService;
+import com.as.we.make.aswemake.share.ResponseBody;
+import com.as.we.make.aswemake.share.StatusCode;
+import com.google.gson.Gson;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+public class AccountControllerTest {
+    @InjectMocks
+    private AccountController accountController;
+
+    @Mock
+    private AccountService accountService;
+
+    @Mock
+    private AccountRepository accountRepository;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void init() {
+        mockMvc = MockMvcBuilders.standaloneSetup(accountController).build();
+    }
+
+    @DisplayName("계정 생성 Controller 테스트")
+    @Test
+    void createAccountTest() throws Exception {
+        // given
+        AccountRequestDto accountRequestDto = AccountRequestDto.builder()
+                .accountEmail("mart@naver.com")
+                .accountPwd("mart9999!!!!")
+                .authority("mart")
+                .build();
+
+        doReturn(new ResponseEntity<>(new ResponseBody(StatusCode.IT_WORK, accountResponseDto(accountRequestDto)), HttpStatus.OK))
+                .when(accountService)
+                .createAccount(any(AccountRequestDto.class));
+
+        String accountRequestInfo = new Gson().toJson(accountRequestDto);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.post("/awm/account/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(accountRequestInfo));
+
+        // then
+        ResultActions resultActionsThen = resultActions
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accountEmail").value(accountRequestDto.getAccountEmail()))
+                .andExpect(jsonPath("$.data.authority").value(accountRequestDto.getAuthority()));
+
+        System.out.println(resultActionsThen);
+    }
+
+
+    // 정사적으로 반환되었을 경우의 데이터 Dto
+    private AccountResponseDto accountResponseDto(AccountRequestDto accountRequestDto) {
+        return AccountResponseDto.builder()
+                .accountEmail(accountRequestDto.getAccountEmail())
+                .authority(accountRequestDto.getAuthority())
+                .build();
+    }
+}

--- a/src/test/java/com/as/we/make/aswemake/AccountServiceTest.java
+++ b/src/test/java/com/as/we/make/aswemake/AccountServiceTest.java
@@ -1,0 +1,53 @@
+package com.as.we.make.aswemake;
+
+import com.as.we.make.aswemake.account.domain.Account;
+import com.as.we.make.aswemake.account.repository.AccountRepository;
+import com.as.we.make.aswemake.account.request.AccountRequestDto;
+import com.as.we.make.aswemake.account.service.AccountService;
+import com.as.we.make.aswemake.exception.AccountExceptionInterface;
+import com.google.gson.Gson;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@ExtendWith(MockitoExtension.class)
+public class AccountServiceTest {
+
+    @InjectMocks
+    private AccountService accountService;
+
+    @Mock
+    private AccountRepository accountRepository;
+
+    @Mock
+    private AccountExceptionInterface accountExceptionInterface;
+
+    @DisplayName("계정 생성 Service 테스트")
+    @Test
+    void createAccountTest(){
+
+        // 테스트 계정 생성 객체
+        AccountRequestDto accountRequestDto = AccountRequestDto.builder()
+                .accountEmail("mart@naver.com")
+                .accountPwd("mart9999!!!!")
+                .authority("mart")
+                .build();
+
+        // 계정 생성 후 반환되는 상태 코드 값
+        int statusCode = accountService.createAccount(accountRequestDto).getBody().getStatusCode();
+
+        // 생성이 완료된 이후 반환 데이터 String으로 변환하여 확인
+        String resultData = new Gson().toJson(accountService.createAccount(accountRequestDto).getBody().getData());
+        System.out.println("반환되는 데이터 : " + resultData);
+
+        // then
+        // 상태 코드 값이 정상처리된 200인지 확인
+        assertThat(statusCode).isEqualTo(200);
+    }
+}


### PR DESCRIPTION
[Setting/Account]

- 계정 생성을 위한 AccountController - createAccount api 생성
- 계정 생성 비즈니스 로직 수행을 위한 AccountService - createAccount 메소드 생성
- 계정 정보를 저장하고 관리하기 위한 AccountRepository 생성
- 계정 엔티티 Account 생성
- 계정 생성 요청을 위한 AccountRequestDto 객체 생성
- 계정 생성 후 결과 확인을 위한 반환 AccountResponseDto 객체 생성
- Account 관련 예외 처리를 위한 AccountException, AccountExceptionInterface 생성
- 반환값 양식의 일관성을 위한 ResponseBody, 상태 정보 값을 저장할 StatusCode 객체 생성
- 테스트를 위한 AccountControllerTest, AccountServiceTest 테스트 코드 작성 - Mockito