### PR TITLE
최종 결제 api 구현 (+쿠폰)

### DIFF
--- a/src/main/java/com/as/we/make/aswemake/AsWeMakeApplication.java
+++ b/src/main/java/com/as/we/make/aswemake/AsWeMakeApplication.java
@@ -1,18 +1,47 @@
 package com.as.we.make.aswemake;
 
+import com.as.we.make.aswemake.coupon.domain.Coupon;
+import com.as.we.make.aswemake.coupon.repository.CouponRepository;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Slf4j
+@Configuration
 @EnableJpaAuditing
 @SpringBootApplication
 public class AsWeMakeApplication {
-
     public static void main(String[] args) {
         SpringApplication.run(AsWeMakeApplication.class, args);
         log.info("application activate ~~~~~~~~~~~~~~~~~~~`");
+    }
+
+    // 테스트를 위한 임의 데이터 즉시 생성
+    @Bean
+    public CommandLineRunner run(CouponRepository couponRepository) throws Exception {
+        return (String[] args) -> {
+
+            if(couponRepository.findAll().isEmpty()){
+                couponRepository.save(
+                        Coupon.builder()
+                                .couponType("FIX")
+                                .discountContent(2000)
+                                .build()
+                );
+
+                couponRepository.save(
+                        Coupon.builder()
+                                .couponType("SPECIFIC")
+                                .discountContent(0.5F)
+                                .build()
+                );
+            }
+
+        };
     }
 
 }

--- a/src/main/java/com/as/we/make/aswemake/account/repository/AccountRepository.java
+++ b/src/main/java/com/as/we/make/aswemake/account/repository/AccountRepository.java
@@ -9,6 +9,10 @@ import java.util.Optional;
 @Repository
 public interface AccountRepository extends JpaRepository<Account, Long> {
 
-    /** 계정 조회 **/
+    /** 이메일로 계정 조회 **/
     Optional<Account> findByAccountEmail(String accountEmail);
+
+    /** 계정 고유 id 로 계정 조회 **/
+    Optional<Account> findByAccountId(Long accountId);
+
 }

--- a/src/main/java/com/as/we/make/aswemake/coupon/domain/Coupon.java
+++ b/src/main/java/com/as/we/make/aswemake/coupon/domain/Coupon.java
@@ -1,0 +1,26 @@
+package com.as.we.make.aswemake.coupon.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+@Entity
+public class Coupon {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long couponId;
+
+    @Column(nullable = false)
+    private String couponType;
+
+    @Column(nullable = false)
+    private float discountContent;
+
+}

--- a/src/main/java/com/as/we/make/aswemake/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/as/we/make/aswemake/coupon/repository/CouponRepository.java
@@ -1,0 +1,12 @@
+package com.as.we.make.aswemake.coupon.repository;
+
+import com.as.we.make.aswemake.coupon.domain.Coupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+
+    /** 사용할 쿠폰 조회 **/
+    Coupon findByCouponId(Long couponId);
+}

--- a/src/main/java/com/as/we/make/aswemake/exception/order/OrderException.java
+++ b/src/main/java/com/as/we/make/aswemake/exception/order/OrderException.java
@@ -1,0 +1,40 @@
+package com.as.we.make.aswemake.exception.order;
+
+import com.as.we.make.aswemake.account.domain.Account;
+import com.as.we.make.aswemake.account.repository.AccountRepository;
+import com.as.we.make.aswemake.order.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class OrderException implements OrderExceptionInterface {
+
+    private final OrderRepository orderRepository;
+    private final AccountRepository accountRepository;
+
+    /** 자기가 주문한 내역이 아닌 것은 결제 할 수 없음을 확인 **/
+    @Override
+    public boolean checkMyOrderBeforPay(Long ordersId, Long accountId) {
+
+        Account account = accountRepository.findByAccountId(accountId)
+                .orElseThrow(() -> new NullPointerException("존재하지 않는 계정입니다."));
+
+        if(orderRepository.findByOrdersIdAndAccount(ordersId, account).isEmpty()){
+            return true;
+        }
+
+        return false;
+    }
+
+    /** 주문 내역의 총 금액보다 지불 금액이 부족한지 확인 **/
+    @Override
+    public boolean checkPaymentCost(Integer orderTotalPrice, Integer paymentCost) {
+
+        if(orderTotalPrice > paymentCost){
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/com/as/we/make/aswemake/exception/order/OrderExceptionInterface.java
+++ b/src/main/java/com/as/we/make/aswemake/exception/order/OrderExceptionInterface.java
@@ -1,0 +1,11 @@
+package com.as.we.make.aswemake.exception.order;
+
+public interface OrderExceptionInterface {
+
+    /** 자기가 주문한 내역이 아닌 것은 결제 할 수 없음을 확인 **/
+    boolean checkMyOrderBeforPay(Long ordersId, Long accountId);
+
+    /** 주문 내역의 총 금액보다 지불 금액이 부족한지 확인 **/
+    boolean checkPaymentCost(Integer orderTotalPrice, Integer paymentCost);
+
+}

--- a/src/main/java/com/as/we/make/aswemake/order/controller/OrderController.java
+++ b/src/main/java/com/as/we/make/aswemake/order/controller/OrderController.java
@@ -1,6 +1,7 @@
 package com.as.we.make.aswemake.order.controller;
 
 import com.as.we.make.aswemake.order.request.OrderRequestDto;
+import com.as.we.make.aswemake.pay.request.PayOrderRequestDto;
 import com.as.we.make.aswemake.order.service.OrderService;
 import com.as.we.make.aswemake.share.ResponseBody;
 import jakarta.servlet.http.HttpServletRequest;
@@ -28,8 +29,8 @@ public class OrderController {
     }
 
 
-    // 주문할 상품들 총 금액 계산 및 조회
-    @GetMapping("/calculate")
+    // 주문할 상품들 총 금액 계산 및 조회 (주문 내용 확정 - 총 금액 업데이트)
+    @PatchMapping("/calculate")
     public ResponseEntity<ResponseBody> calculateTotalOrderPrice(@RequestParam Long ordersId){
         log.info("주문 상품들 총 금액 계산 조회 api - controller : 조회 주문 = {}", ordersId);
 

--- a/src/main/java/com/as/we/make/aswemake/order/domain/Orders.java
+++ b/src/main/java/com/as/we/make/aswemake/order/domain/Orders.java
@@ -4,16 +4,14 @@ import com.as.we.make.aswemake.account.domain.Account;
 import com.as.we.make.aswemake.product.domain.Product;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.HashMap;
 import java.util.Map;
 
 @AllArgsConstructor
 @NoArgsConstructor
+@Setter
 @Getter
 @Builder
 @Entity
@@ -26,13 +24,16 @@ public class Orders {
     @Column(nullable = false)
     private Integer deliveryPay;
 
+    @Column
+    private Integer totalPrice;
+
     @ElementCollection
     @MapKeyColumn(name = "productId")
     @Column(name = "productCount")
     private Map<Product, Integer> products = new HashMap<>();
 
     @JsonIgnore
-    @JoinColumn(name = "orderAccountId")
-    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "accountId")
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private Account account;
 }

--- a/src/main/java/com/as/we/make/aswemake/order/repository/OrderRepository.java
+++ b/src/main/java/com/as/we/make/aswemake/order/repository/OrderRepository.java
@@ -1,5 +1,6 @@
 package com.as.we.make.aswemake.order.repository;
 
+import com.as.we.make.aswemake.account.domain.Account;
 import com.as.we.make.aswemake.order.domain.Orders;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -11,4 +12,7 @@ public interface OrderRepository extends JpaRepository<Orders, Long> {
 
     /** 주문 조회 **/
     Optional<Orders> findByOrdersId(Long ordersId);
+
+    /** 자기가 등록한 주문 내역 조회 **/
+    Optional<Orders> findByOrdersIdAndAccount(Long ordersId, Account account);
 }

--- a/src/main/java/com/as/we/make/aswemake/pay/controller/PayController.java
+++ b/src/main/java/com/as/we/make/aswemake/pay/controller/PayController.java
@@ -1,0 +1,27 @@
+package com.as.we.make.aswemake.pay.controller;
+
+import com.as.we.make.aswemake.pay.request.PayOrderRequestDto;
+import com.as.we.make.aswemake.pay.service.PayService;
+import com.as.we.make.aswemake.share.ResponseBody;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/awm")
+@RestController
+public class PayController {
+
+    private final PayService payService;
+
+    // 등록된 주문 내역 결제
+    @PostMapping("/pay")
+    public ResponseEntity<ResponseBody> payOrder(HttpServletRequest request, @RequestBody PayOrderRequestDto payOrderRequestDto){
+        log.info("주문 내역 결제 api - controller : 결제자 = {}, 결제 주문 내역 id = {}, 결제 지불 금액 = {}", request, payOrderRequestDto.getOrdersId(), payOrderRequestDto.getPaymentCost());
+
+        return payService.payOrder(request, payOrderRequestDto);
+    }
+}

--- a/src/main/java/com/as/we/make/aswemake/pay/domain/PaymentDetails.java
+++ b/src/main/java/com/as/we/make/aswemake/pay/domain/PaymentDetails.java
@@ -1,0 +1,44 @@
+package com.as.we.make.aswemake.pay.domain;
+
+import com.as.we.make.aswemake.coupon.domain.Coupon;
+import com.as.we.make.aswemake.order.domain.Orders;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+@Entity
+public class PaymentDetails {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long paymentDetailsId;
+
+    @Column(nullable = false)
+    private Integer totalPrice;
+
+    @Column(nullable = false)
+    private Integer paymentCost;
+
+    @Column(nullable = false)
+    private Integer remainCost;
+
+    @Column(nullable = false)
+    private String couponWhether;
+
+    @Column(nullable = false)
+    private Integer discountPrice;
+
+    @JoinColumn(name = "couponId")
+    @OneToOne(fetch = FetchType.LAZY)
+    private Coupon coupon;
+
+    @JoinColumn(name = "ordersId")
+    @OneToOne(fetch = FetchType.LAZY)
+    private Orders order;
+}

--- a/src/main/java/com/as/we/make/aswemake/pay/repository/PayRepository.java
+++ b/src/main/java/com/as/we/make/aswemake/pay/repository/PayRepository.java
@@ -1,0 +1,9 @@
+package com.as.we.make.aswemake.pay.repository;
+
+import com.as.we.make.aswemake.pay.domain.PaymentDetails;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PayRepository extends JpaRepository<PaymentDetails, Long> {
+}

--- a/src/main/java/com/as/we/make/aswemake/pay/request/PayOrderRequestDto.java
+++ b/src/main/java/com/as/we/make/aswemake/pay/request/PayOrderRequestDto.java
@@ -1,0 +1,25 @@
+package com.as.we.make.aswemake.pay.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class PayOrderRequestDto {
+    private Long ordersId; // 결제할 주문 내역 id
+    private Integer paymentCost; // 지불 금액
+    private String couponWhether; // 쿠폰 사용 여부 (O / X)
+    private Long couponId; // 사용할 쿠폰 id
+    private String couponScope; // 쿠폰 적용 범위 (ALL / SPECIFIC)
+    private Long specificProductId; // scope 가 specific 일 경우에만 적용 상품 id가 들어옵니다.
+
+    /**
+     * 1. couponWhether가 O일 경우, couponId와 couponScope 는 반드시 같이 입력되어야 합니다.
+     * 2. couponScope가 SPECIFIC일 경우에만, specificProductId 에 id 값이 입력되어있어야 합니다.
+     *
+     */
+}

--- a/src/main/java/com/as/we/make/aswemake/pay/response/PayResponseDto.java
+++ b/src/main/java/com/as/we/make/aswemake/pay/response/PayResponseDto.java
@@ -1,0 +1,18 @@
+package com.as.we.make.aswemake.pay.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class PayResponseDto {
+    private Integer totalPrice;
+    private Integer paymentCost;
+    private Integer remainCost;
+    private String couponWhether;
+    private Integer discountPrice;
+}

--- a/src/main/java/com/as/we/make/aswemake/pay/service/PayService.java
+++ b/src/main/java/com/as/we/make/aswemake/pay/service/PayService.java
@@ -1,0 +1,207 @@
+package com.as.we.make.aswemake.pay.service;
+
+import com.as.we.make.aswemake.account.domain.Account;
+import com.as.we.make.aswemake.coupon.domain.Coupon;
+import com.as.we.make.aswemake.coupon.repository.CouponRepository;
+import com.as.we.make.aswemake.exception.order.OrderExceptionInterface;
+import com.as.we.make.aswemake.exception.token.TokenExceptionInterface;
+import com.as.we.make.aswemake.jwt.JwtTokenProvider;
+import com.as.we.make.aswemake.order.domain.Orders;
+import com.as.we.make.aswemake.order.repository.OrderRepository;
+import com.as.we.make.aswemake.pay.domain.PaymentDetails;
+import com.as.we.make.aswemake.pay.repository.PayRepository;
+import com.as.we.make.aswemake.pay.request.PayOrderRequestDto;
+import com.as.we.make.aswemake.pay.response.PayResponseDto;
+import com.as.we.make.aswemake.product.domain.Product;
+import com.as.we.make.aswemake.share.ResponseBody;
+import com.as.we.make.aswemake.share.StatusCode;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.LinkedHashMap;
+
+@RequiredArgsConstructor
+@Service
+public class PayService {
+
+    private final TokenExceptionInterface tokenExceptionInterface;
+    private final OrderExceptionInterface orderExceptionInterface;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final OrderRepository orderRepository;
+    private final CouponRepository couponRepository;
+    private final PayRepository payRepository;
+
+
+    /** 등록된 주문 내역 결제 **/
+    public ResponseEntity<ResponseBody> payOrder(HttpServletRequest request, PayOrderRequestDto payOrderRequestDto){
+
+        // 요청 토큰 확인
+        if (!tokenExceptionInterface.checkToken(request)) {
+            return new ResponseEntity<>(new ResponseBody(StatusCode.NOT_CORRECT_TOKEN, null), HttpStatus.BAD_REQUEST);
+        }
+
+        // 로그인 하여 ContextHolder에 저장된 인증된 유저 호출
+        Account account = jwtTokenProvider.getMemberFromAuthentication();
+
+        // 자기가 주문한 내역이 아닐 경우 결제할 수 없음
+        if(orderExceptionInterface.checkMyOrderBeforPay(payOrderRequestDto.getOrdersId(), account.getAccountId())){
+            return new ResponseEntity<>(new ResponseBody(StatusCode.CANNOT_PAY_ORDER, null), HttpStatus.BAD_REQUEST);
+        }
+
+        // 결제할 주문 내역 조회
+        Orders payOrder = orderRepository.findByOrdersId(payOrderRequestDto.getOrdersId())
+                .orElseThrow(() -> new NullPointerException("존재하지 않는 주문 내역입니다."));
+
+        // 주문 내역의 총 금액보다 지불 금액이 부족한지 확인
+        if(orderExceptionInterface.checkPaymentCost(payOrder.getTotalPrice(), payOrderRequestDto.getPaymentCost())){
+            return new ResponseEntity<>(new ResponseBody(StatusCode.SHORTAGE_OF_MONEY, null), HttpStatus.BAD_REQUEST);
+        }
+
+        // 최종 결제 정보를 담는 Dto 객체
+        PayResponseDto payResponseDto;
+
+        // 쿠폰을 사용할 경우
+        if(payOrderRequestDto.getCouponWhether().equals("O")){
+            // 최종적으로 결제될 금액
+            int totalPrice = 0;
+            // 사용할 쿠폰 조회
+            Coupon coupon = couponRepository.findByCouponId(payOrderRequestDto.getCouponId());
+            // 할인 금액
+            int discountPrice = 0;
+
+            // 쿠폰 적용 범위가 전체일 경우
+            if(payOrderRequestDto.getCouponScope().equals("ALL")){
+
+                // 쿠폰의 타입이 고정일 경우
+                if(coupon.getCouponType().equals("FIX")){
+
+                    // 고정 할인 금액
+                    discountPrice = (int)coupon.getDiscountContent();
+                    // 전체일 경우 배달비를 제외한 금액에서 고정 할인 비용 차감
+                    totalPrice = (payOrder.getTotalPrice() - payOrder.getDeliveryPay()) - discountPrice;
+                    // 할인된 이후 다시 배달비 추가
+                    totalPrice += payOrder.getDeliveryPay();
+
+                    // 쿠폰의 타입이 비율일 경우
+                }else if(coupon.getCouponType().equals("RATIO")){
+
+                    // 비율 할인 금액
+                    discountPrice = ((payOrder.getTotalPrice() - payOrder.getDeliveryPay()) * (int)coupon.getDiscountContent());
+                    // 전체일 경우 배달비를 제외한 금액
+                    totalPrice = (payOrder.getTotalPrice() - payOrder.getDeliveryPay()) - discountPrice;
+                    // 할인된 이후 다시 배달비 추가
+                    totalPrice += payOrder.getDeliveryPay();
+                }
+
+                // 쿠폰 적용 범위가 특정 상품만일 경우
+            }else if(payOrderRequestDto.getCouponScope().equals("SPECIFIC")){
+
+                // 쿠폰의 타입이 고정일 경우
+                if(coupon.getCouponType().equals("FIX")){
+
+                    // 주문 내역에 저장된 상품들 정보 조회
+                    for (Product eachProduct : payOrder.getProducts().keySet()) {
+
+                        // 특정 상품만을 고정 가격 할인할 경우 해당 특정 상품의 가격과 개수를 곱한 가격에 고정 가격 할인
+                        if(eachProduct.getProductId() == payOrderRequestDto.getSpecificProductId()){
+                            discountPrice = (int)coupon.getDiscountContent();
+                            totalPrice += eachProduct.getPrice() * payOrder.getProducts().get(eachProduct) - discountPrice;
+
+                            // 특정 상품 이외의 할인이 적용되지 않는 상품들은 기존처럼 해당 상품의 가격과 개수를 곱한 가격으로 저장
+                        }else{
+                            totalPrice += eachProduct.getPrice() * payOrder.getProducts().get(eachProduct);
+                        }
+                    }
+
+                    // 할인된 상품의 가격과 다른 상품들의 가격들을 합한 가격에서 최종적으로 배달비까지 추가
+                    totalPrice += payOrder.getDeliveryPay();
+
+                    // 쿠폰의 타입이 비율일 경우
+                }else if(coupon.getCouponType().equals("RATIO")){
+
+                    // 주문 내역에 저장된 상품들 정보 조회
+                    for (Product eachProduct : payOrder.getProducts().keySet()) {
+
+                        // 특정 상품만을 비율 할인할 경우 해당 특정 상품의 가격과 개수를 곱한 가격에 해당 비율만큼 가격 할인
+                        if(eachProduct.getProductId() == payOrderRequestDto.getSpecificProductId()){
+                            discountPrice = ((eachProduct.getPrice() * payOrder.getProducts().get(eachProduct)) * (int)coupon.getDiscountContent());
+                            totalPrice += (eachProduct.getPrice() * payOrder.getProducts().get(eachProduct)) - discountPrice;
+
+                            // 특정 상품 이외의 할인이 적용되지 않는 상품들은 기존처럼 해당 상품의 가격과 개수를 곱한 가격으로 저장
+                        }else{
+                            totalPrice += eachProduct.getPrice() * payOrder.getProducts().get(eachProduct);
+                        }
+                    }
+
+                    // 할인된 상품의 가격과 다른 상품들의 가격들을 합한 가격에서 최종적으로 배달비까지 추가
+                    totalPrice += payOrder.getDeliveryPay();
+                }
+            }
+
+            // 결제 내역 정보 input
+            PaymentDetails paymentDetails = PaymentDetails.builder()
+                    .totalPrice(totalPrice)
+                    .paymentCost(payOrderRequestDto.getPaymentCost())
+                    .remainCost(payOrderRequestDto.getPaymentCost() - totalPrice)
+                    .couponWhether("O")
+                    .discountPrice(discountPrice)
+                    .coupon(coupon)
+                    .order(payOrder)
+                    .build();
+
+            // 결제 내역 저장
+            payRepository.save(paymentDetails);
+
+            // 결제할 주문 정보들에 쿠폰 할인이 적용된 결과를 확인하기 위한 Dto 객체
+            payResponseDto = PayResponseDto.builder()
+                    .totalPrice(totalPrice)
+                    .paymentCost(payOrderRequestDto.getPaymentCost())
+                    .remainCost(payOrderRequestDto.getPaymentCost() - totalPrice)
+                    .couponWhether("O")
+                    .discountPrice(discountPrice)
+                    .build();
+
+            // 쿠폰을 사용하지 않을 경우
+        }else{
+
+            // 결제 내역 정보 input
+            PaymentDetails paymentDetails = PaymentDetails.builder()
+                    .totalPrice(payOrder.getTotalPrice())
+                    .paymentCost(payOrderRequestDto.getPaymentCost())
+                    .remainCost(payOrderRequestDto.getPaymentCost() - payOrder.getTotalPrice())
+                    .couponWhether("X")
+                    .discountPrice(0)
+                    .order(payOrder)
+                    .build();
+
+            // 결제 내역 저장
+            payRepository.save(paymentDetails);
+
+            // 결제할 주문 정보들에 쿠폰 할인이 적용되지 않았을 경우의 결과를 확인하기 위한 Dto 객체
+            payResponseDto = PayResponseDto.builder()
+                    .totalPrice(payOrder.getTotalPrice())
+                    .paymentCost(payOrderRequestDto.getPaymentCost())
+                    .remainCost(payOrderRequestDto.getPaymentCost() - payOrder.getTotalPrice())
+                    .couponWhether("X")
+                    .discountPrice(0)
+                    .build();
+        }
+
+        return new ResponseEntity<>(new ResponseBody(StatusCode.IT_WORK, resultSet("결제 되었습니다.", payResponseDto)), HttpStatus.OK);
+    }
+
+
+    // 최종적으로 결과를 반환하기 위한 method
+    private LinkedHashMap<String, Object> resultSet(String message, Object responseData) {
+
+        // 정상 반환 시 반환되는 메세지와 데이터
+        LinkedHashMap<String, Object> resultSet = new LinkedHashMap<>();
+        resultSet.put("resultMessage", message);
+        resultSet.put("resultData", responseData);
+
+        return resultSet;
+    }
+}

--- a/src/main/java/com/as/we/make/aswemake/share/StatusCode.java
+++ b/src/main/java/com/as/we/make/aswemake/share/StatusCode.java
@@ -18,7 +18,11 @@ public enum StatusCode {
     // 정상적으로 인증된 토큰이 아닌 경우
     NOT_CORRECT_TOKEN(454, "인증된 토큰이 아닙니다."),
     // 상품 관리 가능 권한이 아닐 경우
-    CANNOT_POSSIBLE_AUTHORITY(455, "상품 관리가 가능한 권한이 아닙니다.");
+    CANNOT_POSSIBLE_AUTHORITY(455, "상품 관리가 가능한 권한이 아닙니다."),
+    // 결제하고자 하는 주문 내역이 자기가 등록한 주문 내역이 아닐 경우
+    CANNOT_PAY_ORDER(456, "본인의 주문 내역이 아니라서 결제할 수 없습니다."),
+    // 주문 내역보다 결제 금액이 부족할 경우
+    SHORTAGE_OF_MONEY(457, "결제 금액이 부족합니다.");
 
     public Integer statusCode;
     public String statusMessage;

--- a/src/test/java/com/as/we/make/aswemake/order/OrdersServiceTest.java
+++ b/src/test/java/com/as/we/make/aswemake/order/OrdersServiceTest.java
@@ -18,20 +18,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.mock.web.MockHttpServletRequest;
-
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 
 //@DataJpaTest
 //@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)

--- a/src/test/java/com/as/we/make/aswemake/pay/PayControllerTest.java
+++ b/src/test/java/com/as/we/make/aswemake/pay/PayControllerTest.java
@@ -1,0 +1,178 @@
+package com.as.we.make.aswemake.pay;
+
+import com.as.we.make.aswemake.account.domain.Account;
+import com.as.we.make.aswemake.account.repository.AccountRepository;
+import com.as.we.make.aswemake.coupon.domain.Coupon;
+import com.as.we.make.aswemake.coupon.repository.CouponRepository;
+import com.as.we.make.aswemake.order.domain.Orders;
+import com.as.we.make.aswemake.order.repository.OrderRepository;
+import com.as.we.make.aswemake.order.request.OrderRequestDto;
+import com.as.we.make.aswemake.order.response.OrderProductResponseVo;
+import com.as.we.make.aswemake.order.response.OrderResponseDto;
+import com.as.we.make.aswemake.pay.controller.PayController;
+import com.as.we.make.aswemake.pay.repository.PayRepository;
+import com.as.we.make.aswemake.pay.request.PayOrderRequestDto;
+import com.as.we.make.aswemake.pay.response.PayResponseDto;
+import com.as.we.make.aswemake.pay.service.PayService;
+import com.as.we.make.aswemake.product.domain.Product;
+import com.as.we.make.aswemake.product.repository.ProductRepository;
+import com.as.we.make.aswemake.share.ResponseBody;
+import com.as.we.make.aswemake.share.StatusCode;
+import com.google.gson.Gson;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.*;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SuppressWarnings("unchecked")
+@ExtendWith(MockitoExtension.class)
+public class PayControllerTest {
+
+    @InjectMocks
+    private PayController payController;
+
+    @Mock
+    private PayService payService;
+
+    @Mock
+    private PayRepository payRepository;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private CouponRepository couponRepository;
+
+    @Mock
+    private AccountRepository accountRepository;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void init() {
+        mockMvc = MockMvcBuilders.standaloneSetup(payController).build();
+    }
+
+
+    @DisplayName("최종 결제 Controller 테스트")
+    @Test
+    void payOrderTest() throws Exception {
+        // given
+        Account account = Account.builder()
+                .accountId(1L)
+                .accountEmail("test@naver.com")
+                .accountPwd("test")
+                .authority(Collections.singletonList("MART"))
+                .build();
+
+        accountRepository.save(account);
+
+        HashMap<Product, Integer> products = new HashMap<>();
+
+        for (int i = 1; i < 3; i++) {
+            Product product = Product.builder()
+                    .productId((long) i)
+                    .productName("테스트 상품 " + i)
+                    .price(3000)
+                    .build();
+
+            productRepository.save(product);
+
+            products.put(product, 1);
+        }
+
+        Orders order = Orders.builder()
+                .ordersId(1L)
+                .deliveryPay(5000)
+                .totalPrice(6000)
+                .account(account)
+                .products(products)
+                .build();
+
+        orderRepository.save(order);
+
+        Coupon coupon = Coupon.builder()
+                .couponId(1L)
+                .couponType("FIX")
+                .discountContent(2000)
+                .build();
+
+        couponRepository.save(coupon);
+
+        PayOrderRequestDto payOrderRequestDto = PayOrderRequestDto.builder()
+                .ordersId(1L)
+                .paymentCost(15000)
+                .couponWhether("O")
+                .couponId(1L)
+                .couponScope("ALL")
+                .specificProductId(0L)
+                .build();
+
+        PayResponseDto payResponseDto = PayResponseDto.builder()
+                .totalPrice(9000)
+                .paymentCost(payOrderRequestDto.getPaymentCost())
+                .remainCost(payOrderRequestDto.getPaymentCost() - 9000)
+                .couponWhether("O")
+                .discountPrice((int) coupon.getDiscountContent())
+                .build();
+
+
+        doReturn(new ResponseEntity<>(new ResponseBody(StatusCode.IT_WORK, resultSet("결제 완료", payResponseDto)), HttpStatus.OK))
+                .when(payService)
+                .payOrder(any(HttpServletRequest.class), any(PayOrderRequestDto.class));
+
+        String payRequest = new Gson().toJson(payOrderRequestDto);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                MockMvcRequestBuilders.post("/awm/pay")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyQG5hdmVyLmNvbSIsImF1dGgiOiJVU0VSIiwiZXhwIjoxNjg4NjA2MTk1fQ.gPC0VUZPlTcqUXli__q3VEQx4vJzaNSRgPOrgAIDmrw")
+                        .characterEncoding("utf-8")
+                        .content(payRequest));
+
+        // then
+        ResultActions resultActionsThen = resultActions
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.resultData.totalPrice").value(9000));
+
+        System.out.println(resultActionsThen);
+    }
+
+
+
+    // 테스트 결과 확인 데이터
+    private LinkedHashMap<String, Object> resultSet(String message, Object data) {
+
+        LinkedHashMap<String, Object> resultSet = new LinkedHashMap<>();
+        resultSet.put("resultMessage", message);
+        resultSet.put("resultData", data);
+
+        return resultSet;
+    }
+
+}

--- a/src/test/java/com/as/we/make/aswemake/pay/PayServiceTest.java
+++ b/src/test/java/com/as/we/make/aswemake/pay/PayServiceTest.java
@@ -1,0 +1,152 @@
+package com.as.we.make.aswemake.pay;
+
+
+import com.as.we.make.aswemake.account.domain.Account;
+import com.as.we.make.aswemake.account.repository.AccountRepository;
+import com.as.we.make.aswemake.account.request.AccountLoginRequestDto;
+import com.as.we.make.aswemake.account.service.AccountService;
+import com.as.we.make.aswemake.coupon.domain.Coupon;
+import com.as.we.make.aswemake.coupon.repository.CouponRepository;
+import com.as.we.make.aswemake.exception.token.TokenExceptionInterface;
+import com.as.we.make.aswemake.jwt.JwtTokenProvider;
+import com.as.we.make.aswemake.order.domain.Orders;
+import com.as.we.make.aswemake.order.repository.OrderRepository;
+import com.as.we.make.aswemake.order.request.OrderRequestDto;
+import com.as.we.make.aswemake.order.response.OrderProductResponseVo;
+import com.as.we.make.aswemake.order.service.OrderService;
+import com.as.we.make.aswemake.pay.request.PayOrderRequestDto;
+import com.as.we.make.aswemake.pay.response.PayResponseDto;
+import com.as.we.make.aswemake.pay.service.PayService;
+import com.as.we.make.aswemake.product.domain.Product;
+import com.as.we.make.aswemake.product.repository.ProductRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletContext;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+
+
+@SuppressWarnings("unchecked")
+@ExtendWith(MockitoExtension.class)
+public class PayServiceTest {
+
+    @InjectMocks
+    private PayService payService;
+
+    @InjectMocks
+    private AccountService accountService;
+
+    @Mock
+    private TokenExceptionInterface tokenExceptionInterface;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private AccountRepository accountRepository;
+
+    @Mock
+    private CouponRepository couponRepository;
+
+
+
+    @DisplayName("최종 결제 Service 테스트")
+    @Test
+    void payOrderTest() throws Exception {
+
+        // given
+        Account account = Account.builder()
+                .accountId(1L)
+                .accountEmail("test@naver.com")
+                .accountPwd("test")
+                .authority(Collections.singletonList("MART"))
+                .build();
+
+        accountRepository.save(account);
+
+        AccountLoginRequestDto loginRequestDto = AccountLoginRequestDto.builder()
+                .accountPwd(account.getAccountPwd())
+                .accountEmail(account.getAccountEmail())
+                .build();
+
+
+//        MockHttpServletResponse response = new MockHttpServletResponse();
+//        accountService.loginAccount(loginRequestDto, response);
+//        MockHttpServletRequest request = new MockHttpServletRequest(new MockServletContext());
+        HashMap<Product, Integer> products = new HashMap<>();
+
+        for (int i = 1; i < 3; i++) {
+            Product product = Product.builder()
+                    .productId((long) i)
+                    .productName("테스트 상품 " + i)
+                    .price(3000)
+                    .build();
+
+            productRepository.save(product);
+
+            products.put(product, 1);
+        }
+
+        Orders order = Orders.builder()
+                .ordersId(1L)
+                .deliveryPay(5000)
+                .totalPrice(6000)
+                .account(account)
+                .products(products)
+                .build();
+
+        orderRepository.save(order);
+
+        Coupon coupon = Coupon.builder()
+                .couponId(1L)
+                .couponType("FIX")
+                .discountContent(2000)
+                .build();
+
+        couponRepository.save(coupon);
+
+        PayOrderRequestDto payOrderRequestDto = PayOrderRequestDto.builder()
+                .ordersId(1L)
+                .paymentCost(15000)
+                .couponWhether("O")
+                .couponId(1L)
+                .couponScope("ALL")
+                .specificProductId(0L)
+                .build();
+
+        PayResponseDto payResponseDto = PayResponseDto.builder()
+                .totalPrice(9000)
+                .paymentCost(payOrderRequestDto.getPaymentCost())
+                .remainCost(payOrderRequestDto.getPaymentCost() - 9000)
+                .couponWhether("O")
+                .discountPrice((int) coupon.getDiscountContent())
+                .build();
+
+
+        // 계정 생성 후 반환되는 상태 코드 값
+        int statusCode = payService.payOrder(any(MockHttpServletRequest.class), payOrderRequestDto).getBody().getStatusCode();
+
+        // then
+        // 상태 코드 값이 정상처리된 200인지 확인
+        assertThat(statusCode).isEqualTo(200);
+
+    }
+
+
+}


### PR DESCRIPTION
[Feature/Order/Pay]
- 결제 내역이 저장될 PaymentDetails 엔티티 생성
- PayController 최종 결제 api 구현
- PayService 최종 결제 비즈니스 로직 method 생성
- PayRepository 결제 내역 데이터를 관리할 jpa 레포지토리 생성
- 결제 요청 객체 PayOrderRequestDto 생성
- 정상적으로 결제 완료 후 결과 확인을 위한 반환 객체 PayResponseDto 생성
- 기존에 OrderController, OrderService에 같이 운영되었던 결제 api를 PayController, PayService 로 분리하여 관리
- 총 금액 속성을 Orders 엔티티에서 PaymentDetails 엔티티로 이동
- 결제 진행 시 자기가 주문한 내역이 맞는지 확인하는 예외 처리, 결제 지불 금액이 총 금액보다 같거나 이상인지 확인하는 예외 처리 부분을 포함한 OrderException, OrderExceptionInterface 생성
- OrderRepository에 자신이 등록한 주문 내역을 확인 조회하는 jpa 함수 추가
- 고정 할인 쿠폰, 비율 할인 쿠폰을 가진 Coupon 엔티티 생성
- CouponRepository 쿠폰을 저장하기 위한 jpa 레포지토리 생성
- AsWeMakeApplication 어플리케이션 실행 시 초기에 쿠폰이 자동 생성될 수 있도록 처리
- StatusCode 상태 처리 코드 추가
- PayControllerTest, PayServiceTest 테스트 코드 일부 작성