### PR TITLE
상품 조회 api 구현 (+특정 시점 상품의 가격 조회)

### DIFF
--- a/src/main/java/com/as/we/make/aswemake/configuration/SecurityConfig.java
+++ b/src/main/java/com/as/we/make/aswemake/configuration/SecurityConfig.java
@@ -32,7 +32,8 @@ public class SecurityConfig {
                 .sessionManagement((session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests((authorize) -> authorize
                         .requestMatchers("/awm/account/**",
-                                "/awm/order/calculate").permitAll()
+                                "/awm/order/calculate",
+                                "/awm/product/get").permitAll()
                         // product api 경로에는 MART 권한을 가진 계정만이 접근가능하게 하는 옵션. 하지만 USER 권한을 가진 계정이 접근했을 경우의 예외처리를 확인하기 위해 주석처리
                         // .requestMatchers("/awm/product/**").hasAuthority("MART")
                         .anyRequest().authenticated()

--- a/src/main/java/com/as/we/make/aswemake/product/controller/ProductController.java
+++ b/src/main/java/com/as/we/make/aswemake/product/controller/ProductController.java
@@ -11,6 +11,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
+
 @RequiredArgsConstructor
 @Slf4j
 @RequestMapping("/awm/product")
@@ -41,6 +43,14 @@ public class ProductController {
         log.info("상품 삭제 api - controller : 상품 번호 = {}, 삭제 요청 계정 = {}", productDeleteRequestDto.getProductId(), request);
 
         return productService.deleteProduct(request, productDeleteRequestDto);
+    }
+
+    // 상품 조회
+    @GetMapping("/get")
+    public ResponseEntity<ResponseBody> getProduct(@RequestParam Long productId, @RequestParam(required = false) String getDateTime){
+        log.info("상품 조회 api - controller : 조회 상품 id = {}", productId);
+
+        return productService.getProduct(productId, getDateTime);
     }
 
 }

--- a/src/main/java/com/as/we/make/aswemake/product/domain/ProductUpdateDetails.java
+++ b/src/main/java/com/as/we/make/aswemake/product/domain/ProductUpdateDetails.java
@@ -1,0 +1,38 @@
+package com.as.we.make.aswemake.product.domain;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+@Entity
+public class ProductUpdateDetails {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long productUpdateDetailsId;
+
+    @Column(nullable = false)
+    private Integer price;
+
+    @Column(nullable = false)
+    private String productName;
+
+    @Column(nullable = false)
+    private LocalDateTime updateTime;
+
+    @JsonIgnore
+    @JoinColumn(name = "productId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Product product;
+
+}

--- a/src/main/java/com/as/we/make/aswemake/product/repository/ProductUpdateDetailsRepository.java
+++ b/src/main/java/com/as/we/make/aswemake/product/repository/ProductUpdateDetailsRepository.java
@@ -1,0 +1,16 @@
+package com.as.we.make.aswemake.product.repository;
+
+import com.as.we.make.aswemake.product.domain.Product;
+import com.as.we.make.aswemake.product.domain.ProductUpdateDetails;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ProductUpdateDetailsRepository extends JpaRepository<ProductUpdateDetails, Long> {
+
+    /** 조회하고자 하는 상품의 정보 이력들 조회 **/
+    Optional<List<ProductUpdateDetails>> findAllByProductOrderByUpdateTimeDesc(Product product);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=jdbc:mysql://localhost:3306/aswemake?serverTimezone=UTC&characterEncoding=UTF-8
+spring.datasource.url=jdbc:mysql://localhost:3306/aswemake?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
 spring.datasource.username=root
 spring.datasource.password=wls124578!
 


### PR DESCRIPTION
[Feature/Product/GetProduct]
- ProductController 상품 조회 api 구현
- ProductService 상품 조회 비즈니스 로직 구현
- ProductService 상품 생성 및 수정 로직에 상품 업데이트 이력도 같이 저장되게 업데이트
- ProductUpdateDetails 상품의 업데이트 이력을 관리하는 엔티티 생성
- ProductUpdateDetailsRepository 상품 이력을 관리하는 jpa 레포지토리 생성
- application.properties MySQL 드라이버 시간 설정 Asia/Seoul로 변경
- ProductControllerTest 테스트 코드 일부 작성