### PR TITLE
api 명세화를 위한 Swagger 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,10 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // Swagger : api 자동 문서화
+    implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.1.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/as/we/make/aswemake/configuration/SecurityConfig.java
+++ b/src/main/java/com/as/we/make/aswemake/configuration/SecurityConfig.java
@@ -33,7 +33,9 @@ public class SecurityConfig {
                 .authorizeHttpRequests((authorize) -> authorize
                         .requestMatchers("/awm/account/**",
                                 "/awm/order/calculate",
-                                "/awm/product/get").permitAll()
+                                "/awm/product/get",
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**").permitAll()
                         // product api 경로에는 MART 권한을 가진 계정만이 접근가능하게 하는 옵션. 하지만 USER 권한을 가진 계정이 접근했을 경우의 예외처리를 확인하기 위해 주석처리
                         // .requestMatchers("/awm/product/**").hasAuthority("MART")
                         .anyRequest().authenticated()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,4 +21,4 @@ server.servlet.encoding.force=true
 spring.jackson.serialization.FAIL_ON_EMPTY_BEANS=false
 spring.main.allow-bean-definition-overriding=true
 spring.mvc.pathmatch.matching-strategy=ant_path_matcher
-
+springdoc.swagger-ui.path=/swagger-ui.html


### PR DESCRIPTION
[Swagger]
- build.gradle에 api 명세화를 위한 Swagger 디펜던시 추가
- SecurityConfig에 Swagger 경로 허용 설정
- application.properties에 Swagger path 설정 추가